### PR TITLE
Addet soft_reset()-Macro to crm.h for restart. Addet nvm_verify()-Functi...

### DIFF
--- a/lib/include/crm.h
+++ b/lib/include/crm.h
@@ -325,6 +325,17 @@ static const int XTAL32_EN =   0;
 #define pack_XTAL_CNTL(ctune4pf, ctune, ftune, ibias) \
 	(*CRM_XTAL_CNTL = ((ctune4pf << 25) | (ctune << 21) | ( ftune << 16) | (ibias << 8) | 0x52))
 
+#define soft_reset() \
+    __asm__ __volatile__ ( \
+        "ldr r0, [%[sw]] \n\t" \
+        "str r0, [%[sw]] \n\t" \
+    : /* out */ \
+    : /* in */ \
+        [sw] "l" (CRM_SW_RST) \
+    : /* clobber list */ \
+        "r0", "memory" \
+    );
+
 #endif /* REG_NO_COMPAT */
 
 #endif

--- a/lib/include/nvm.h
+++ b/lib/include/nvm.h
@@ -78,5 +78,6 @@ extern nvmErr_t (*nvm_write)(nvmInterface_t nvmInterface, nvmType_t nvmType ,voi
 /* SST flash has 32 sectors 4096 bytes each */
 /* bit 0 is the first sector, bit 31 is the last */
 extern nvmErr_t (*nvm_erase)(nvmInterface_t nvmInterface, nvmType_t nvmType ,uint32_t sectorBitfield);
+extern nvmErr_t (*nvm_verify)(nvmInterface_t nvmInterface, nvmType_t nvmType, void *pSrc, uint32_t address, uint32_t numBytes);
 extern void(*nvm_setsvar)(uint32_t zero_for_awesome);
 #endif //NVM_H

--- a/lib/nvm.c
+++ b/lib/nvm.c
@@ -51,7 +51,10 @@ nvmErr_t (*nvm_erase)
 (nvmInterface_t nvmInterface, nvmType_t nvmType ,uint32_t sectorBitfield) 
 = (void*) 0x00006e05;
 
+nvmErr_t (*nvm_verify)
+(nvmInterface_t nvmInterface, nvmType_t nvmType, void *pSrc, uint32_t address, uint32_t numBytes)
+= (void*) 0x00006f85;
+
 void(*nvm_setsvar)
 (uint32_t zero_for_awesome) 
 = (void *)0x00007085;
-


### PR DESCRIPTION
- add soft_reset()-Macro to crm.h for restart
- add nvm_verify()-Function in nvm.x for compare ram-data with flash-data
- change flashing: new parameter -l for using files which include binary-len
  in the first 4 byte and additional data after binary. without -l you can flash
  like before.
