### PR TITLE
BOARD: econotag and Bugfix

### DIFF
--- a/board/econotag.h
+++ b/board/econotag.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2010, Mariano Alvira <mar@devl.org> and other contributors
+ * to the MC1322x project (http://mc1322x.devl.org)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of libmc1322x: see http://mc1322x.devl.org
+ * for details. 
+ *
+ *
+ */
+
+#ifndef BOARD_REDBEE_ECONOTAG_H
+#define BOARD_REDBEE_ECONOTAG_H
+
+#define GPIO_LED_RED   GPIO_44
+#define GPIO_LED_GREEN GPIO_45
+#define GPIO_LED_BLUE  GPIO_43  /* don't have a blue LED so we use IO43 */
+
+#define LED_RED   44
+#define LED_GREEN 45
+#define LED_BLUE  43	/* don't have a blue LED so we reuse red */
+
+/* XTAL TUNE parameters */
+/* see http://devl.org/pipermail/mc1322x/2009-December/000162.html */
+/* for details about how to make this measurement */
+
+/* Econotag also needs an addtional 12pf on board */
+/* Coarse tune: add 4pf */
+#define CTUNE_4PF 1
+/* Coarse tune: add 0-15 pf (CTUNE is 4 bits) */
+#define CTUNE 11
+/* Fine tune: add FTUNE * 156fF (FTUNE is 5bits) */
+#define FTUNE 7
+
+#include <std_conf.h>
+
+#endif

--- a/tools/ftditools/bbmc.c
+++ b/tools/ftditools/bbmc.c
@@ -118,6 +118,10 @@ static struct layout layouts[] =
 	  .desc = "Redbee Econotag",
 	  std_layout(REDBEE_ECONOTAG)
 	},
+	{ .name = "redbee-econotag",
+	  .desc = "Redbee Econotag",
+	  std_layout(REDBEE_ECONOTAG)
+	},
 	{ .name = "redbee-usb",
 	  .desc = "Redbee USB stick",
 	  std_layout(REDBEE_USB)

--- a/tools/ftditools/bbmc.c
+++ b/tools/ftditools/bbmc.c
@@ -114,7 +114,7 @@ void usage(void);
 	
 static struct layout layouts[] =
 {
-	{ .name = "redbee-econotag",
+	{ .name = "econotag",
 	  .desc = "Redbee Econotag",
 	  std_layout(REDBEE_ECONOTAG)
 	},

--- a/tools/mc1322x-load.c
+++ b/tools/mc1322x-load.c
@@ -259,10 +259,10 @@ int main(int argc, char **argv) {
       printf("Sending %i...\n", s);
       write(pfd, (const void*)&s, 4);
     }
-  }
 
-  /* Wait for flasher done */
-  waitFor("flasher done", 0);
+    /* Wait for flasher done */
+    waitFor("flasher done", 0);
+  }
 
   /* Send the remaining arguments */
   if (args) {


### PR DESCRIPTION
Addet board "econotag" to lib and bbmc for easy using with the new Contiki, where "redbee-econotag" ist deprecated.

Also fixed a bug in mc1322x-load.c. Without the use of -s or -z, there is no need for waiting to "flasher done".
The Perl-Version dont have this Problem.
